### PR TITLE
FIX: escape attribute's value that is type of string

### DIFF
--- a/axmlparserpy/axmlprinter.py
+++ b/axmlparserpy/axmlprinter.py
@@ -25,6 +25,7 @@ from bytecode import SV
 import StringIO
 from struct import pack, unpack
 from xml.dom import minidom
+from xml.sax import saxutils
 
 class AXMLPrinter:
     def __init__(self, raw_buff):
@@ -76,7 +77,7 @@ class AXMLPrinter:
 
         #print _type, _data
         if _type == tc.TYPE_STRING:
-            return self.axml.getAttributeValue(index)
+            return saxutils.escape(self.axml.getAttributeValue(index), entities={'"': '&quot;'})
 
         elif _type == tc.TYPE_ATTRIBUTE:
             return "?%s%08X" % (self.getPackage(_data), _data)


### PR DESCRIPTION
replace the string value ('<', '&', '>', '"') to ('&lt;', '&amp;', '&gt;', '&quot;')
