### PR TITLE
fix ValueError in py2.7

### DIFF
--- a/axmlparserpy/stringblock.py
+++ b/axmlparserpy/stringblock.py
@@ -86,7 +86,7 @@ class StringBlock:
         while length > 0:
             offset += 2
             # Unicode character
-            data += chr(self.getShort(self.m_strings, offset))
+            data += unichr(self.getShort(self.m_strings, offset))
 
             # FIXME
             if data[-1] == "&":


### PR DESCRIPTION
```
  File "/local/lib/python2.7/site-packages/axmlparserpy/axmlparser.py", line 254, in getAttributeValue
    return self.sb.getRaw(valueString)
  File "/local/lib/python2.7/site-packages/axmlparserpy/stringblock.py", line 89, in getRaw
    data += chr(self.getShort(self.m_strings, offset))
ValueError: chr() arg not in range(256)
```